### PR TITLE
MuMaMo 使用中のバッファで yascroll を無効にする回避策

### DIFF
--- a/yascroll.el
+++ b/yascroll.el
@@ -303,7 +303,10 @@ and disable `yascroll-bar-mode'."
   "Return non-nil if yascroll is enabled on BUFFER."
   (with-current-buffer buffer
     (and (not (minibufferp))
-         (not (memq major-mode yascroll:disabled-modes)))))
+         (not (memq major-mode yascroll:disabled-modes))
+         ;; Disable yascroll when using mumamo
+         (not (and (boundp 'mumamo-multi-major-mode)
+                   (eval 'mumamo-multi-major-mode))))))
 
 (defun yascroll:turn-on ()
   (when (yascroll:enabled-buffer-p (current-buffer))


### PR DESCRIPTION
[MuMaMo](http://www.emacswiki.org/emacs/MuMaMo) 使用中のバッファで yascroll を有効にすると scroll bar がちぎれてしまいます。こんな感じです:

<a href="http://www.flickr.com/photos/arataka/7196935914/" title="screenshot-2012-05-14-181722 by takafumi_a, on Flickr"><img src="http://farm6.staticflickr.com/5452/7196935914_efcabfb297.jpg" width="344" height="449" alt="screenshot-2012-05-14-181722"></a>

また、この状態になると、自動的に隠れなくなってしまいます。

この問題を解決するために MuMaMo を使っているときにだけ yascroll を無効にしたいのですが、 major-mode 変数には MuMaMo を構成する各 chunk の major mode の値が入っているので yascroll:disabled-modes を使っても効果がありません。

MuMaMo が有効になっている場合に yascroll を無効にするために修正を加えました。

他の回避策としては、 buffer local な変数 `yascroll:enable` を用意して、以下のように変更し、あとはこの変数の変更はユーザーにまかせても良いかもしれません。

``` lisp
(defun yascroll:enabled-buffer-p (buffer)
  "Return non-nil if yascroll is enabled on BUFFER."
  (with-current-buffer buffer
    (and (not (minibufferp))
         (not (memq major-mode yascroll:disabled-modes))
         yascroll:enable)))
```
