### PR TITLE
use cl-lib library instead of cl library

### DIFF
--- a/yascroll.el
+++ b/yascroll.el
@@ -326,4 +326,7 @@ and disable `yascroll-bar-mode'."
   :group 'yascroll)
 
 (provide 'yascroll)
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; End:
 ;;; yascroll.el ends here


### PR DESCRIPTION
Use `cl-loop` intead of `loop` and in one case remove the WITH clause
and instead wrap the `cl-loop` with `cl-destructuring-bind`.  It appears
that the `cl-lib` of Emacs v24.4 no longer supports destructuring in the
WITH clause.

Fixes issue #13.
