### PR TITLE
Fix window-margins calc and scrollbar moving off-screen

### DIFF
--- a/yascroll.el
+++ b/yascroll.el
@@ -51,9 +51,7 @@ logical position to the right-edge of the window, and PADDING is
 a positive number of padding to the edge."
   (save-excursion
     (let* ((window-width (window-width))
-           (window-margin (destructuring-bind (left-margin . right-margin)
-                              (window-margins)
-                            (+ (or left-margin 0) (or right-margin 0))))
+           (window-margin (+ left-margin-width right-margin-width))
            (column-bol (progn (yascroll:vertical-motion (cons 0 0))
                               (current-column)))
            (column-eol (progn (yascroll:vertical-motion

--- a/yascroll.el
+++ b/yascroll.el
@@ -145,7 +145,7 @@ scroll bar."
     (floor (* window-lines (/ (float scroll-top) buffer-lines)))))
 
 (defun yascroll:make-thumb-overlay-text-area ()
-  (destructuring-bind (edge-pos edge-padding)
+  (cl-destructuring-bind (edge-pos edge-padding)
       (yascroll:line-edge-position)
     (if (= edge-pos (line-end-position))
         (let ((overlay (make-overlay edge-pos edge-pos))
@@ -247,7 +247,7 @@ scroll bar."
                  (thumb-size (yascroll:compute-thumb-size
                               window-lines buffer-lines))
                  (make-thumb-overlay
-                  (ecase scroll-bar
+                  (cl-ecase scroll-bar
                     (left-fringe 'yascroll:make-thumb-overlay-left-fringe)
                     (right-fringe 'yascroll:make-thumb-overlay-right-fringe)
                     (text-area 'yascroll:make-thumb-overlay-text-area))))

--- a/yascroll.el
+++ b/yascroll.el
@@ -237,7 +237,7 @@ scroll bar."
   (yascroll:hide-scroll-bar)
   (let ((scroll-bar (yascroll:choose-scroll-bar)))
     (when scroll-bar
-      (let ((window-lines (window-height))
+      (let ((window-lines (yascroll:window-height))
             (buffer-lines (count-lines (point-min) (point-max))))
         (when (< window-lines buffer-lines)
           (let* ((scroll-top (count-lines (point-min) (window-start)))
@@ -256,6 +256,14 @@ scroll bar."
                                             thumb-window-line
                                             thumb-size)
               (yascroll:schedule-hide-scroll-bar))))))))
+
+(defun yascroll:window-height ()
+  "`line-spacing'-aware calculation of `window-height'."
+  (if (and (fboundp 'window-pixel-height)
+           (fboundp 'line-pixel-height)
+           (display-graphic-p))
+      (/ (window-pixel-height) (line-pixel-height))
+    (window-height)))
 
 ;;;###autoload
 (defun yascroll:hide-scroll-bar ()


### PR DESCRIPTION
This is a great package -- I hope it continues to see development, so I'm putting a couple fixes up for consideration.

1. `(window-margins)` can return `(nil)` (i.e. `(list nil)`) which means the `destructuring-bind` will fail -- there aren't two variables to tease apart.  Fortunately, I think since Emacs 22 we can access the intended variables directly.

2. As of Emacs 26.1, `(window-height)` returns the window height of the frame assuming zero `line-spacing`.  If I set `line-spacing` to nonzero, the scrollbar doesn't calibrate correctly and slides down off the screen well before I reach the end of the buffer.  I think what we actually want is `(/ (window-pixel-height) (line-pixel-height))` (when those functions are available -- they aren't in Emacs 22).

