### PR TITLE
Support display-line-numbers-mode

### DIFF
--- a/yascroll.el
+++ b/yascroll.el
@@ -51,7 +51,11 @@
 logical position to the right-edge of the window, and PADDING is \
 a positive number of padding to the edge."
   (save-excursion
-    (let* ((window-width (window-width))
+    (let* ((line-number-width
+            (if (and (>= emacs-major-version 26) display-line-numbers-mode)
+                (+ (line-number-display-width) 2)
+              0))
+           (window-width (- (window-width) line-number-width))
            (window-margin (+ left-margin-width right-margin-width))
            (column-bol (progn (yascroll:vertical-motion (cons 0 0))
                               (current-column)))

--- a/yascroll.el
+++ b/yascroll.el
@@ -52,7 +52,7 @@ logical position to the right-edge of the window, and PADDING is \
 a positive number of padding to the edge."
   (save-excursion
     (let* ((line-number-width
-            (if (and (>= emacs-major-version 26) display-line-numbers-mode)
+            (if (and (boundp 'display-line-numbers-mode) display-line-numbers-mode)
                 (+ (line-number-display-width) 2)
               0))
            (window-width (- (window-width) line-number-width))


### PR DESCRIPTION
In emacs 26, `display-line-numbers-mode` doesn't reduce the value of available columns in `window-width` when enabled, so this needs to be addressed separately when needed, as it is in the calculation of line-edge-position in yascroll.