### PR TITLE
Add additional padding when horizontal scrolling has passed EOL.

### DIFF
--- a/yascroll.el
+++ b/yascroll.el
@@ -63,7 +63,11 @@ a positive number of padding to the edge."
            (padding (- window-width
                        window-margin
                        column-eol-visual
-                       (if window-system 0 1))))
+                       (if window-system 0 1)))
+           ;; When horizontal scroll has passed EOL, add padding for the columns
+           ;; between EOL and the first column in the visible window.
+           (padding (+ padding
+                       (- (max (window-hscroll) column-eol) column-eol))))
       (list (point) padding))))
 
 


### PR DESCRIPTION
I use horizontal scrolling a lot (S-right and S-left) and yascroll has a glaring bug when lines pass out of the visual frame as seen in this screenshot. The non-scrolled version is compared to the right with 12 columns `scroll-left` (M-1 M-2 C-x <)

![yascroll-horizontal-bug](https://user-images.githubusercontent.com/287699/74782612-0fb73300-52a4-11ea-9ed7-de725be4906a.png)

As seen in the picture, the problem is on lines not visible in the frame, and the scroll bar offset is also dependent on how far out of the frame it is. This PR adds this additional padding when horizontal scroll has passed eol.

Semi-related appendix: To trigger scrollbar update on horizontal scrolling I have this keybindings:
```elisp
(defun my-scroll-with-hook (scroll-fun &optional arg)
  (funcall scroll-fun arg)
  (run-hook-with-args-until-failure
   'window-scroll-functions (selected-window) (point)))

(global-set-key [S-right]  '(lambda() (interactive) (my-scroll-with-hook 'scroll-left 6)))
(global-set-key [S-left]   '(lambda() (interactive) (my-scroll-with-hook 'scroll-right 6)))
```