### PR TITLE
Don't substract margin width, (window-width) does this for us.

### DIFF
--- a/yascroll.el
+++ b/yascroll.el
@@ -58,7 +58,6 @@ a positive number of padding to the edge."
                 (+ (line-number-display-width) 2)
               0))
            (window-width (- (window-width) line-number-width))
-           (window-margin (+ left-margin-width right-margin-width))
            (column-bol (progn (yascroll:vertical-motion (cons 0 0))
                               (current-column)))
            (column-eol (progn (yascroll:vertical-motion
@@ -67,7 +66,6 @@ a positive number of padding to the edge."
            (column-eol-visual (- column-eol column-bol))
 
            (padding (- window-width
-                       window-margin
                        column-eol-visual
                        (if window-system 0 1)))
            ;; When horizontal scroll has passed EOL, add padding for the columns


### PR DESCRIPTION
The code for calculating the padding width in `yascroll:line-edge-position` (text-area scrollbar) subtracts the left and right margins from `window-width`, but this is already accounted for in the `(window-width)` function. The margins are subtracted twice. Provided screenshots shows how this materializes.

Upstream, master, with margin subtraction:

![Screenshot from 2020-02-19 22-51-15](https://user-images.githubusercontent.com/287699/74881084-f5955780-536c-11ea-8f62-17929a7b064d.png)

PR without margin subtraction:

![Screenshot from 2020-02-19 22-48-28](https://user-images.githubusercontent.com/287699/74881140-165dad00-536d-11ea-8e1f-7249eb5e877d.png)
