### PR TITLE
Add support for Emacs Mac Port

### DIFF
--- a/yascroll.el
+++ b/yascroll.el
@@ -117,12 +117,13 @@ not be displayed."
   :group 'yascroll)
 
 (defcustom yascroll:enabled-window-systems
-  '(nil x w32 ns pc)
+  '(nil x w32 ns pc mac)
   "A list of window-system's where yascroll can work."
   :type '(repeat (choice (const :tag "Termcap" nil)
                          (const :tag "X window" x)
                          (const :tag "MS-Windows" w32)
                          (const :tag "Macintosh Cocoa" ns)
+                         (const :tag "Macintosh Emacs Port" mac)
                          (const :tag "MS-DOS" pc)))
   :group 'yascroll)
 


### PR DESCRIPTION
This was created to replace #17 because I already long since deleted the fork.

> This simply adds `'mac` to `yascroll:enabled-window-systems`, which is the `display-system` for a popular mac port of Emacs by Yamamoto Mitsuharu: https://github.com/railwaycat/mirror-emacs-mac/blob/master/README-mac available on Homebrew in OSX.