### PR TITLE
Workaround buggy vertical-motion

### DIFF
--- a/yascroll.el
+++ b/yascroll.el
@@ -60,12 +60,12 @@ a positive number of padding to the edge."
            (window-width (- (window-width) line-number-width))
            (window-hscroll (window-hscroll))
            ;; Beginning of *window* line, i.e. if truncation is off we’re
-           ;; computing the continued line’s BOL. If we’re scrolled
+           ;; computing the continued line’s BOL column. If we’re scrolled
            ;; horizontally, truncation is always on and BOL is always 0.
            (column-bol (if (or truncate-lines (> window-hscroll 0))
                            0
                          (progn (yascroll:vertical-motion (cons 0 0))
-                              (current-column))))
+                                (current-column))))
            (column-eol (progn (yascroll:vertical-motion
                                (cons (- window-width 1 (if window-system 0 1)) 0))
                               (current-column)))

--- a/yascroll.el
+++ b/yascroll.el
@@ -58,13 +58,23 @@ a positive number of padding to the edge."
                 (+ (line-number-display-width) 2)
               0))
            (window-width (- (window-width) line-number-width))
+           (window-hscroll (window-hscroll))
+           ;; Beginning of *window* line, i.e. if truncation is off we’re
+           ;; computing the continued line’s BOL. If we’re scrolled
+           ;; horizontally, truncation is always on and BOL is always 0.
+           (column-bol (if (or truncate-lines (> window-hscroll 0))
+                           0
+                         (progn (yascroll:vertical-motion (cons 0 0))
+                              (current-column))))
            (column-eol (progn (yascroll:vertical-motion
                                (cons (- window-width 1 (if window-system 0 1)) 0))
                               (current-column)))
-           (padding (- window-width column-eol (if window-system 0 1)))
+           (padding (- window-width
+                       (- column-eol column-bol)
+                       (if window-system 0 1)))
            ;; When horizontal scroll has passed EOL, add padding for the columns
            ;; between EOL and the first column in the visible window.
-           (padding (+ padding (window-hscroll))))
+           (padding (+ padding window-hscroll)))
       (list (point) padding))))
 
 

--- a/yascroll.el
+++ b/yascroll.el
@@ -59,22 +59,18 @@ a positive number of padding to the edge."
               0))
            (window-width (- (window-width) line-number-width))
            (window-hscroll (window-hscroll))
-           ;; Beginning of *window* line, i.e. if truncation is off we’re
-           ;; computing the continued line’s BOL column. If we’re scrolled
-           ;; horizontally, truncation is always on and BOL is always 0.
+           (tty-offset (if (display-graphic-p) 0 1))
+           ;; If truncation is off we’re computing the continued line’s first
+           ;; column. With horizontal scroll truncation is always on and we can
+           ;; use it’s value as first visible column.
            (column-bol (if (or truncate-lines (> window-hscroll 0))
-                           0
+                           window-hscroll
                          (progn (yascroll:vertical-motion (cons 0 0))
                                 (current-column))))
            (column-eol (progn (yascroll:vertical-motion
-                               (cons (- window-width 1 (if window-system 0 1)) 0))
+                               (cons (- window-width 1 tty-offset) 0))
                               (current-column)))
-           (padding (- window-width
-                       (- column-eol column-bol)
-                       (if window-system 0 1)))
-           ;; When horizontal scroll has passed EOL, add padding for the columns
-           ;; between EOL and the first column in the visible window.
-           (padding (+ padding window-hscroll)))
+           (padding (- window-width (- column-eol column-bol) tty-offset)))
       (list (point) padding))))
 
 

--- a/yascroll.el
+++ b/yascroll.el
@@ -58,20 +58,13 @@ a positive number of padding to the edge."
                 (+ (line-number-display-width) 2)
               0))
            (window-width (- (window-width) line-number-width))
-           (column-bol (progn (yascroll:vertical-motion (cons 0 0))
-                              (current-column)))
            (column-eol (progn (yascroll:vertical-motion
                                (cons (- window-width 1 (if window-system 0 1)) 0))
                               (current-column)))
-           (column-eol-visual (- column-eol column-bol))
-
-           (padding (- window-width
-                       column-eol-visual
-                       (if window-system 0 1)))
+           (padding (- window-width column-eol (if window-system 0 1)))
            ;; When horizontal scroll has passed EOL, add padding for the columns
            ;; between EOL and the first column in the visible window.
-           (padding (+ padding
-                       (- (max (window-hscroll) column-eol) column-eol))))
+           (padding (+ padding (window-hscroll))))
       (list (point) padding))))
 
 


### PR DESCRIPTION
This PR addresses more bugs when showing the scroll bar in the text area.

`vertical-motion` is buggy when used with `display-line-numbers-mode`. There are two major bugs that causes yascroll to hickup:

1. In Emacs 26.1 (not in 26.3) the following elisp line when eval-ed in a window narrower than the full line will not return two columns less than available, but something less. And I haven't investigated this to the full extent, but my guess is that `vertical-motion` actually takes into account the with of display-line-numbers-mode, although they clearly says they don't. The value 4 is from the combination of two spaces around (line-number-display-width) and two characters for yascroll to position its scrollbar in tty mode:
```elisp
(progn (yascroll:vertical-motion (cons (- (window-width) (line-number-display-width) 4) 0)) (current-column)) ; A very long comment which soul purpose is to debug yascroll.
```
2. In Emacs 26.3 (not in 26.1) eval-ing this line will set the cursor in column 2, not 1 as expected:
```elisp
(progn (scroll-left 1) (vertical-motion (cons 0 0)) (current-column))                                  
```

Together they make working with `(vertical-motion)` to calculate positions in text a bit difficult. The master branch as of today still hurts from both these bugs. This PR have no solution for bug 1., but has a workaround for bug 2. in that it never uses `vertical-motion` if horizontal scroll is active. As # 1. seems to be fixed in 26.3 and assuming later versions as well, this isn't prioritized.

What this PR does is:
1. Workaround bug # 2. by using the `(window-hscroll)` as starting column if truncation is active. This was the original solution to yascroll prior to fringe-rendering support added 8 years ago, but it didn't support wrapped lines.
2. Fixes a bug with `page-break-mode.el` enabled which caused yascroll to disable when the scrollbar was on the same line as ^L and horizontal scroll active.
3. Uses `(display-graphics-p)` instead of `window-system` to test for graphics capabilities, as recommended.
