### PR TITLE
Don't run in image-mode by default

### DIFF
--- a/yascroll.el
+++ b/yascroll.el
@@ -127,7 +127,7 @@ not be displayed."
   :group 'yascroll)
 
 (defcustom yascroll:disabled-modes
-  nil
+  '(image-mode)
   "A list of major-modes where yascroll can't work."
   :type '(repeat symbol)
   :group 'yascroll)


### PR DESCRIPTION
In case it's still possible to submit PRs to this package, I believe this is a sensible default. Running this minor-mode in `image-mode` only increases the image load times and doesn't do anything since the image is just one huge line