### PR TITLE
Allow pgtk (pure gtk3) window-system by default

### DIFF
--- a/yascroll.el
+++ b/yascroll.el
@@ -123,14 +123,15 @@ not be displayed."
   :group 'yascroll)
 
 (defcustom yascroll:enabled-window-systems
-  '(nil x w32 ns pc mac)
+  '(nil x w32 ns pc mac pgtk)
   "A list of window-system's where yascroll can work."
   :type '(repeat (choice (const :tag "Termcap" nil)
                          (const :tag "X window" x)
                          (const :tag "MS-Windows" w32)
                          (const :tag "Macintosh Cocoa" ns)
                          (const :tag "Macintosh Emacs Port" mac)
-                         (const :tag "MS-DOS" pc)))
+                         (const :tag "MS-DOS" pc)
+                         (const :tag "Pure GTK3 Emacs Fork" pgtk)))
   :group 'yascroll)
 
 (defcustom yascroll:disabled-modes


### PR DESCRIPTION
There are unofficial emacs forks which use pure GTK and thus support wayland
natively. They have the `window-system` with value `pgtk`, which was not in the list of allowed window systems by default, so I added it. I tested this with the `emacs-pgtk-native-comp-git` [1] package by
flatwhatson from the Archlinux User Repository, which is based on hist fork [2] on github.

[1]: https://aur.archlinux.org/packages/emacs-pgtk-native-comp-git/
[2]: https://github.com/flatwhatson/emacs/tree/pgtk-nativecomp

Solves #32