### PR TITLE
Warning if window system is not supported

### DIFF
--- a/yascroll.el
+++ b/yascroll.el
@@ -243,16 +243,22 @@ Doc-this WINDOW-LINES, BUFFER-LINES and SCROLL-TOP."
 
 (defun yascroll:choose-scroll-bar ()
   "Choose scroll bar by fringe position."
-  (when (memq window-system yascroll:enabled-window-systems)
-    (cl-destructuring-bind (left-width right-width outside-margins &rest _)
-        (window-fringes)
-      (cl-loop for scroll-bar in (yascroll:listify yascroll:scroll-bar)
-               if (or (eq scroll-bar 'text-area)
-                      (and (eq scroll-bar 'left-fringe)
-                           (> left-width 0))
-                      (and (eq scroll-bar 'right-fringe)
-                           (> right-width 0)))
-               return scroll-bar))))
+  (if (memq window-system yascroll:enabled-window-systems)
+      (cl-destructuring-bind (left-width right-width outside-margins &rest _)
+          (window-fringes)
+        (cl-loop for scroll-bar in (yascroll:listify yascroll:scroll-bar)
+                 if (or (eq scroll-bar 'text-area)
+                        (and (eq scroll-bar 'left-fringe)
+                             (> left-width 0))
+                        (and (eq scroll-bar 'right-fringe)
+                             (> right-width 0)))
+                 return scroll-bar))
+
+    (display-warning
+     'yascroll
+     (format "Not enabling yascroll because window-system '%s' is not in '%s' %s"
+             window-system 'yascroll:enabled-window-systems yascroll:enabled-window-systems)
+     :warning)))
 
 (defun yascroll:show-scroll-bar-internal ()
   "Show scroll bar in buffer."


### PR DESCRIPTION
If the window system is not supported, yascroll doesn't enable with not warning message. It would be nice to communicate to the user that the window system is not supported to help the user find out why yasnippet does not work. I suggested this in #32 and here implemented this via a warning. Not sure, maybe a simple message would be better. And maybe the message should be placed somewhere else than in the body of `yascroll:choose-scroll-bar`, so that the user isn't spammed with the warning when e.g.switching buffers, so I'd be happy about feedback.